### PR TITLE
Typo in the documentation for examples of "Suffix notation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ using the "kilo", "mega", etc... symbols. All the [SI](http://en.wikipedia.org/w
 
 ```php
 // Prints "1.23k"
-echo Number::n(1234.567)->round(3)->getPrefixNotation();
+echo Number::n(1234.567)->round(3)->getSuffixNotation();
 
 
 // Prints "79G"
-echo Number::n(79123232123)->round(2)->getPrefixNotation();
+echo Number::n(79123232123)->round(2)->getSuffixNotation();
 
 
 // Prints "123.4µ"
-echo Number::n(0.0001234)->getPrefixNotation();
+echo Number::n(0.0001234)->getSuffixNotation();
 ```
 
 ### Format with thousands and decimals separator


### PR DESCRIPTION
README gives examples for the "Suffix notation" and calls method `Numbers\Number::getPrefixNotation()` which does not exists.

Using provided example:
```PHP
<?php
include 'vendor/autoload.php';
use Numbers\Number;
echo Number::n(1234.567)->round(3)->getPrefixNotation();
```
Gives the following output (on PHP v5.6.30):
```
PHP Fatal error:  Call to undefined method Numbers\Number::getPrefixNotation() in /tmp/tmp.2uzN6LWcCX/numbers/test.php on line 4
PHP Stack trace:
PHP   1. {main}() /tmp/tmp.2uzN6LWcCX/numbers/test.php:0
```

The correct method is `Numbers\Number::getSuffixNotation()`.